### PR TITLE
added .js filter to bower scripts build

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -68,7 +68,7 @@ pipes.builtVendorScriptsDev = function() {
 };
 
 pipes.builtVendorScriptsProd = function() {
-    return gulp.src(bowerFiles())
+    return gulp.src(bowerFiles('**/*.js'))
         .pipe(pipes.orderedVendorScripts())
         .pipe(plugins.concat('vendor.min.js'))
         .pipe(plugins.uglify())


### PR DESCRIPTION
Adding the *_/_.js filter to the main-bower-files call in the pipes.buildVendorScriptsProd function allows bower components with .css to be installed (and imported with scss) without adding main overrides in bower.json for every package.
